### PR TITLE
Option to create multiple policies for iam-role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [1.1.0] - 2022-07-25
+### Description
+- Removed permissions boundary policy resource to use aim-policy module instead
+- Feature: role iam_policy refactored to create multiple policies
+
 ## [1.0.4] - 2022-07-04
 ### Description
 - Feature: Option to create a permissions boundary policy when creating a role.
@@ -33,7 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Feature: IAM role Policy
 - Feature: IAM Role
 
-[Unreleased]: https://github.com/boldlink/terraform-aws-iam-role/releases/tag/1.0.4...HEAD
+[Unreleased]: https://github.com/boldlink/terraform-aws-iam-role/releases/tag/1.1.0...HEAD
+
+[1.1.0]: https://github.com/boldlink/terraform-aws-iam-role/releases/tag/1.1.0
 
 [1.0.4]: https://github.com/boldlink/terraform-aws-iam-role/releases/tag/1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0] - 2022-07-25
 ### Description
-- Removed permissions boundary policy resource to use aim-policy module instead
+- Removed permissions boundary policy resource to use iam-policy module instead
 - Feature: role iam_policy refactored to create multiple policies
 
 ## [1.0.4] - 2022-07-04

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ No modules.
 | <a name="output_create_date"></a> [create\_date](#output\_create\_date) | Creation date of the IAM role. |
 | <a name="output_id"></a> [id](#output\_id) | Name of the role. |
 | <a name="output_name"></a> [name](#output\_name) | Name of the role. |
-| <a name="output_policy_arn"></a> [policy\_arn](#output\_policy\_arn) | The ARN assigned by AWS to this policy. |
-| <a name="output_policy_description"></a> [policy\_description](#output\_policy\_description) | The description of the policy. |
-| <a name="output_policy_id"></a> [policy\_id](#output\_policy\_id) | The policy's ID. |
-| <a name="output_policy_name"></a> [policy\_name](#output\_policy\_name) | The name of the policy. |
-| <a name="output_policy_path"></a> [policy\_path](#output\_policy\_path) | The path of the policy in IAM. |
+| <a name="output_policy_arns"></a> [policy\_arns](#output\_policy\_arns) | The ARN assigned by AWS to this policy. |
+| <a name="output_policy_descriptions"></a> [policy\_descriptions](#output\_policy\_descriptions) | The description of the policy. |
+| <a name="output_policy_ids"></a> [policy\_ids](#output\_policy\_ids) | The policy's ID. |
+| <a name="output_policy_names"></a> [policy\_names](#output\_policy\_names) | The name of the policy. |
+| <a name="output_policy_paths"></a> [policy\_paths](#output\_policy\_paths) | The path of the policy in IAM. |
 | <a name="output_policy_tags_all"></a> [policy\_tags\_all](#output\_policy\_tags\_all) | A map of tags assigned to the resource, including those inherited from the provider `default_tags` |
 | <a name="output_tags_all"></a> [tags\_all](#output\_tags\_all) | A map of tags assigned to the resource, including those inherited from the provider `default_tags` |
 | <a name="output_unique_id"></a> [unique\_id](#output\_unique\_id) | Stable and unique string identifying the role. |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ locals {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.21.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.23.0 |
 
 ## Modules
 
@@ -66,7 +66,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.permissions_boundary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 
@@ -84,14 +83,7 @@ No modules.
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | (Optional, Forces new resource) Creates a unique friendly name beginning with the specified prefix. Conflicts with `name` | `string` | `null` | no |
 | <a name="input_path"></a> [path](#input\_path) | (Optional) Path to the role | `string` | `"/"` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | (Optional) ARN of the policy that is used to set the permissions boundary for the role. | `string` | `null` | no |
-| <a name="input_permissions_boundary_path"></a> [permissions\_boundary\_path](#input\_permissions\_boundary\_path) | (Optional) Path in which to create the policy. | `string` | `"/"` | no |
-| <a name="input_permissions_boundary_policy"></a> [permissions\_boundary\_policy](#input\_permissions\_boundary\_policy) | (Required) The inline policy document. This is a JSON formatted string. | `string` | `null` | no |
-| <a name="input_permissions_boundary_policy_description"></a> [permissions\_boundary\_policy\_description](#input\_permissions\_boundary\_policy\_description) | (Optional, Forces new resource) Description of the IAM policy. | `string` | `null` | no |
-| <a name="input_permissions_boundary_policy_name"></a> [permissions\_boundary\_policy\_name](#input\_permissions\_boundary\_policy\_name) | (Optional, Forces new resource) The name of the permissions boundary policy. If omitted, Terraform will assign a random, unique name. | `string` | `null` | no |
-| <a name="input_policy"></a> [policy](#input\_policy) | (Required) The inline policy document. This is a JSON formatted string. | `string` | `null` | no |
-| <a name="input_policy_description"></a> [policy\_description](#input\_policy\_description) | (Optional, Forces new resource) Description of the IAM policy. | `string` | `null` | no |
-| <a name="input_policy_name"></a> [policy\_name](#input\_policy\_name) | (Optional, Forces new resource) The name of the policy. If omitted, Terraform will assign a random, unique name. | `string` | `null` | no |
-| <a name="input_policy_path"></a> [policy\_path](#input\_policy\_path) | (Optional) Path in which to create the policy. | `string` | `"/"` | no |
+| <a name="input_policies"></a> [policies](#input\_policies) | A map of policies to be created. | `map(any)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Key-value mapping of tags for the IAM role. If configured with a provider default\_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level. | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -99,16 +91,9 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | Amazon Resource Name (ARN) specifying the role. |
-| <a name="output_aws_assigned_policy_id"></a> [aws\_assigned\_policy\_id](#output\_aws\_assigned\_policy\_id) | The ARN assigned by AWS to this policy. |
 | <a name="output_create_date"></a> [create\_date](#output\_create\_date) | Creation date of the IAM role. |
 | <a name="output_id"></a> [id](#output\_id) | Name of the role. |
 | <a name="output_name"></a> [name](#output\_name) | Name of the role. |
-| <a name="output_permissions_boundary_policy_arn"></a> [permissions\_boundary\_policy\_arn](#output\_permissions\_boundary\_policy\_arn) | The ARN assigned by AWS to this policy. |
-| <a name="output_permissions_boundary_policy_description"></a> [permissions\_boundary\_policy\_description](#output\_permissions\_boundary\_policy\_description) | The description of the permissions boundary policy. |
-| <a name="output_permissions_boundary_policy_id"></a> [permissions\_boundary\_policy\_id](#output\_permissions\_boundary\_policy\_id) | The permissions boundary policy's ID. |
-| <a name="output_permissions_boundary_policy_name"></a> [permissions\_boundary\_policy\_name](#output\_permissions\_boundary\_policy\_name) | The name of the permissions boundary policy. |
-| <a name="output_permissions_boundary_policy_path"></a> [permissions\_boundary\_policy\_path](#output\_permissions\_boundary\_policy\_path) | The path of the permissions boundary policy in IAM. |
-| <a name="output_permissions_boundary_policy_tags_all"></a> [permissions\_boundary\_policy\_tags\_all](#output\_permissions\_boundary\_policy\_tags\_all) | A map of tags assigned to the resource, including those inherited from the provider `default_tags` |
 | <a name="output_policy_arn"></a> [policy\_arn](#output\_policy\_arn) | The ARN assigned by AWS to this policy. |
 | <a name="output_policy_description"></a> [policy\_description](#output\_policy\_description) | The description of the policy. |
 | <a name="output_policy_id"></a> [policy\_id](#output\_policy\_id) | The policy's ID. |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -17,12 +17,13 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.21.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.23.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_boundary_policy"></a> [boundary\_policy](#module\_boundary\_policy) | boldlink/iam-policy/aws | 1.0.2 |
 | <a name="module_complete_managed_policy"></a> [complete\_managed\_policy](#module\_complete\_managed\_policy) | ./../../ | n/a |
 
 ## Resources

--- a/examples/complete/data.tf
+++ b/examples/complete/data.tf
@@ -1,5 +1,6 @@
 data "aws_iam_policy_document" "ec2_assume_role_policy" {
   statement {
+    sid     = "ExampleSTSAssumeRole"
     actions = ["sts:AssumeRole"]
 
     principals {

--- a/examples/complete/locals.tf
+++ b/examples/complete/locals.tf
@@ -1,0 +1,34 @@
+locals {
+  name = "example-complete-role"
+  tags = {
+    environment        = "examples"
+    "user::CostCenter" = "terraform-registry"
+  }
+  role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["ec2:Describe*"]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+  permissions_boundary_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceTypeOfferings",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeInstanceTypes",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeInstanceStatus"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/examples/complete/locals.tf
+++ b/examples/complete/locals.tf
@@ -8,6 +8,7 @@ locals {
     Version = "2012-10-17"
     Statement = [
       {
+        Sid      = "ExampleEC2DesribeAllPolicy"
         Action   = ["ec2:Describe*"]
         Effect   = "Allow"
         Resource = "*"
@@ -18,6 +19,7 @@ locals {
     Version = "2012-10-17"
     Statement = [
       {
+        Sid = "ExampleRolePermissionsBoundary"
         Action = [
           "ec2:DescribeInstances",
           "ec2:DescribeInstanceTypeOfferings",

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,38 +1,25 @@
 
 module "complete_managed_policy" {
-  source                           = "./../../"
-  name                             = "example-complete-role"
-  assume_role_policy               = data.aws_iam_policy_document.ec2_assume_role_policy.json
-  description                      = "Example completerole with a variety of permissions"
-  managed_policy_arns              = ["arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"]
-  force_detach_policies            = true
-  policy_name                      = "Example-customer-managed-policy"
-  permissions_boundary_policy_name = "Example-permission-boundary"
-  permissions_boundary_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = [
-          "ec2:DescribeInstances",
-          "ec2:DescribeInstanceTypeOfferings",
-          "ec2:DescribeVpcs",
-          "ec2:DescribeInstanceTypes",
-          "ec2:DescribeSubnets",
-          "ec2:DescribeInstanceStatus"
-        ]
-        Effect   = "Allow"
-        Resource = "*"
-      },
-    ]
-  })
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action   = ["ec2:Describe*"]
-        Effect   = "Allow"
-        Resource = "*"
-      },
-    ]
-  })
+  source                = "./../../"
+  name                  = local.name
+  assume_role_policy    = data.aws_iam_policy_document.ec2_assume_role_policy.json
+  description           = "Example complete role with a variety of permissions"
+  managed_policy_arns   = ["arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"]
+  force_detach_policies = true
+  tags                  = local.tags
+  permissions_boundary  = module.boundary_policy.policy_arn
+  policies = {
+    "${local.name}-policy" = {
+      policy = local.role_policy
+      tags   = local.tags
+    }
+  }
+}
+
+module "boundary_policy" {
+  source      = "boldlink/iam-policy/aws"
+  version     = "1.0.2"
+  policy_name = "${local.name}-permissions-boundary"
+  description = "Example-permission-boundary"
+  policy      = local.permissions_boundary_policy
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,6 +1,7 @@
 output "outputs" {
   description = "Example complete role output"
   value = [
-    module.complete_managed_policy,
+    module.complete_managed_policy.arn,
+    module.complete_managed_policy.name,
   ]
 }

--- a/examples/minimum/locals.tf
+++ b/examples/minimum/locals.tf
@@ -3,6 +3,7 @@ locals {
     Version = "2012-10-17"
     Statement = [
       {
+        Sid    = "ExampleSTSAssumeRole"
         Action = "sts:AssumeRole"
         Effect = "Allow"
         Sid    = ""

--- a/examples/with_inline_policy/README.md
+++ b/examples/with_inline_policy/README.md
@@ -17,7 +17,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.21.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.23.0 |
 
 ## Modules
 

--- a/examples/with_inline_policy/data.tf
+++ b/examples/with_inline_policy/data.tf
@@ -1,5 +1,7 @@
 data "aws_iam_policy_document" "ec2_assume_role_policy" {
+
   statement {
+    sid     = "ExampleSTSAssumeRole"
     actions = ["sts:AssumeRole"]
 
     principals {
@@ -11,6 +13,7 @@ data "aws_iam_policy_document" "ec2_assume_role_policy" {
 
 data "aws_iam_policy_document" "inline_policy" {
   statement {
+    sid       = "ExampleInlineEC2DescribePolicy"
     actions   = ["ec2:DescribeAccountAttributes"]
     resources = ["*"]
   }

--- a/examples/with_inline_policy/outputs.tf
+++ b/examples/with_inline_policy/outputs.tf
@@ -2,6 +2,7 @@
 output "outputs" {
   description = "Example role with inline policy"
   value = [
-    module.inline_policy,
+    module.inline_policy.arn,
+    module.inline_policy.name,
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -3,11 +3,11 @@ resource "aws_iam_role" "main" {
   assume_role_policy    = var.assume_role_policy
   description           = var.description
   force_detach_policies = var.force_detach_policies
-  managed_policy_arns   = compact(concat(var.managed_policy_arns, [try(aws_iam_policy.main[0].arn, "")]))
+  managed_policy_arns   = concat(var.managed_policy_arns, [for policy in aws_iam_policy.main : policy.arn])
   max_session_duration  = var.max_session_duration
   name_prefix           = var.name == null ? var.name_prefix : null
   path                  = var.path
-  permissions_boundary  = try(aws_iam_policy.permissions_boundary[0].arn, var.permissions_boundary)
+  permissions_boundary  = var.permissions_boundary
   dynamic "inline_policy" {
     for_each = var.inline_policy
 
@@ -24,33 +24,15 @@ resource "aws_iam_role" "main" {
 }
 
 resource "aws_iam_policy" "main" {
-  count       = var.policy != null ? 1 : 0
-  name        = var.policy_name
-  path        = var.policy_path
-  description = var.policy_description
-  policy      = var.policy
-  tags = merge(
-    {
-      "Name" : var.policy_name
-    },
-  var.tags)
+  for_each = var.policies
+  name     = try(each.key, null)
+  path     = try(each.value.path, "/")
+  policy   = each.value.policy
+  tags     = try(each.value.tags, {})
 }
 
 resource "aws_iam_role_policy_attachment" "main" {
-  count      = var.policy != null ? 1 : 0
+  for_each   = var.policies
   role       = aws_iam_role.main.name
-  policy_arn = join("", aws_iam_policy.main.*.arn)
-}
-
-resource "aws_iam_policy" "permissions_boundary" {
-  count       = var.permissions_boundary_policy != null ? 1 : 0
-  name        = var.permissions_boundary_policy_name
-  path        = var.permissions_boundary_path
-  description = var.permissions_boundary_policy_description
-  policy      = var.permissions_boundary_policy
-  tags = merge(
-    {
-      "Name" : var.permissions_boundary_policy_name
-    },
-  var.tags)
+  policy_arn = aws_iam_policy.main[each.key].arn
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,27 +28,27 @@ output "unique_id" {
   description = "Stable and unique string identifying the role."
 }
 
-output "policy_arn" {
+output "policy_arns" {
   value       = [for policy in aws_iam_policy.main : policy.arn]
   description = "The ARN assigned by AWS to this policy."
 }
 
-output "policy_description" {
+output "policy_descriptions" {
   value       = [for policy in aws_iam_policy.main : policy.description]
   description = "The description of the policy."
 }
 
-output "policy_name" {
+output "policy_names" {
   value       = [for policy in aws_iam_policy.main : policy.name]
   description = "The name of the policy."
 }
 
-output "policy_path" {
+output "policy_paths" {
   value       = [for policy in aws_iam_policy.main : policy.path]
   description = "The path of the policy in IAM."
 }
 
-output "policy_id" {
+output "policy_ids" {
   value       = [for policy in aws_iam_policy.main : policy.policy_id]
   description = "The policy's ID."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,67 +28,32 @@ output "unique_id" {
   description = "Stable and unique string identifying the role."
 }
 
-output "aws_assigned_policy_id" {
-  value       = join("", aws_iam_policy.main.*.id)
-  description = "The ARN assigned by AWS to this policy."
-}
-
 output "policy_arn" {
-  value       = join("", aws_iam_policy.main.*.arn)
+  value       = [for policy in aws_iam_policy.main : policy.arn]
   description = "The ARN assigned by AWS to this policy."
 }
 
 output "policy_description" {
-  value       = [aws_iam_policy.main.*.description]
+  value       = [for policy in aws_iam_policy.main : policy.description]
   description = "The description of the policy."
 }
 
 output "policy_name" {
-  value       = join("", aws_iam_policy.main.*.name)
+  value       = [for policy in aws_iam_policy.main : policy.name]
   description = "The name of the policy."
 }
 
 output "policy_path" {
-  value       = join("", aws_iam_policy.main.*.path)
+  value       = [for policy in aws_iam_policy.main : policy.path]
   description = "The path of the policy in IAM."
 }
 
 output "policy_id" {
-  value       = join("", aws_iam_policy.main.*.policy_id)
+  value       = [for policy in aws_iam_policy.main : policy.policy_id]
   description = "The policy's ID."
 }
 
 output "policy_tags_all" {
-  value       = [aws_iam_policy.main.*.tags_all]
-  description = "A map of tags assigned to the resource, including those inherited from the provider `default_tags`"
-}
-
-output "permissions_boundary_policy_arn" {
-  value       = join("", aws_iam_policy.permissions_boundary.*.arn)
-  description = "The ARN assigned by AWS to this policy."
-}
-
-output "permissions_boundary_policy_description" {
-  value       = [aws_iam_policy.permissions_boundary.*.description]
-  description = "The description of the permissions boundary policy."
-}
-
-output "permissions_boundary_policy_name" {
-  value       = join("", aws_iam_policy.permissions_boundary.*.name)
-  description = "The name of the permissions boundary policy."
-}
-
-output "permissions_boundary_policy_path" {
-  value       = join("", aws_iam_policy.permissions_boundary.*.path)
-  description = "The path of the permissions boundary policy in IAM."
-}
-
-output "permissions_boundary_policy_id" {
-  value       = join("", aws_iam_policy.permissions_boundary.*.policy_id)
-  description = "The permissions boundary policy's ID."
-}
-
-output "permissions_boundary_policy_tags_all" {
-  value       = [aws_iam_policy.permissions_boundary.*.tags_all]
+  value       = [for policy in aws_iam_policy.main : policy.tags_all]
   description = "A map of tags assigned to the resource, including those inherited from the provider `default_tags`"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,30 +30,30 @@ output "unique_id" {
 
 output "policy_arns" {
   value       = [for policy in aws_iam_policy.main : policy.arn]
-  description = "The ARN assigned by AWS to this policy."
+  description = "The ARN(s) assigned by AWS to this policy/policies."
 }
 
 output "policy_descriptions" {
   value       = [for policy in aws_iam_policy.main : policy.description]
-  description = "The description of the policy."
+  description = "The description(s) of the policy/ policies."
 }
 
 output "policy_names" {
   value       = [for policy in aws_iam_policy.main : policy.name]
-  description = "The name of the policy."
+  description = "The name(s) of the policy."
 }
 
 output "policy_paths" {
   value       = [for policy in aws_iam_policy.main : policy.path]
-  description = "The path of the policy in IAM."
+  description = "The path(s) of the policy/policies in IAM."
 }
 
 output "policy_ids" {
   value       = [for policy in aws_iam_policy.main : policy.policy_id]
-  description = "The policy's ID."
+  description = "The policy's ID(s)."
 }
 
 output "policy_tags_all" {
   value       = [for policy in aws_iam_policy.main : policy.tags_all]
-  description = "A map of tags assigned to the resource, including those inherited from the provider `default_tags`"
+  description = "A map of tags assigned to the resource(s), including those inherited from the provider `default_tags`"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -40,7 +40,7 @@ output "policy_descriptions" {
 
 output "policy_names" {
   value       = [for policy in aws_iam_policy.main : policy.name]
-  description = "The name(s) of the policy."
+  description = "The name(s) of the policy/policies."
 }
 
 output "policy_paths" {

--- a/variables.tf
+++ b/variables.tf
@@ -65,51 +65,9 @@ variable "tags" {
 }
 
 # IAM Policy
-variable "policy_name" {
-  type        = string
-  description = "(Optional, Forces new resource) The name of the policy. If omitted, Terraform will assign a random, unique name."
-  default     = null
-}
 
-variable "policy_description" {
-  type        = string
-  description = "(Optional, Forces new resource) Description of the IAM policy."
-  default     = null
-}
-
-variable "policy_path" {
-  type        = string
-  description = " (Optional) Path in which to create the policy. "
-  default     = "/"
-}
-
-variable "policy" {
-  type        = string
-  description = "(Required) The inline policy document. This is a JSON formatted string."
-  default     = null
-}
-
-# Permissions Boundary Policy
-variable "permissions_boundary_policy_name" {
-  type        = string
-  description = "(Optional, Forces new resource) The name of the permissions boundary policy. If omitted, Terraform will assign a random, unique name."
-  default     = null
-}
-
-variable "permissions_boundary_policy_description" {
-  type        = string
-  description = "(Optional, Forces new resource) Description of the IAM policy."
-  default     = null
-}
-
-variable "permissions_boundary_path" {
-  type        = string
-  description = " (Optional) Path in which to create the policy. "
-  default     = "/"
-}
-
-variable "permissions_boundary_policy" {
-  type        = string
-  description = "(Required) The inline policy document. This is a JSON formatted string."
-  default     = null
+variable "policies" {
+  type        = map(any)
+  description = "A map of policies to be created."
+  default     = {}
 }


### PR DESCRIPTION
# Description

This PR aims to achieve creation of multiple policies for one role

## Features/Fixes/Patches/Changes list:

Please check the [CHANGELOG.md](https://github.com/boldlink/terraform-aws-iam-role/blob/feature/multiple-policies/CHANGELOG.md#110---2022-07-25)

## Checklists:
### PR Owners Checklist:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [x] Have you updated the `CHANGELOG.md`?
* [x] Have you updated the `README.md`(s)?
* [x] OWNER: Does your submission pass?
    * [x] Pre-commit (attach logs/print screen to this PR)
    * [x] Checkov/terrascan (attach logs/print screen to this PR)
    * [x] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?

<details><summary><b>Checkov scan results:</b></summary>

```bash
       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By bridgecrew.io | version: 2.1.32 
Update available 2.1.32 -> 2.1.75
Run pip3 install -U checkov to update 


terraform scan results:

Passed checks: 33, Failed checks: 0, Skipped checks: 0

Check: CKV_AWS_49: "Ensure no IAM policies documents allow "*" as a statement's actions"
	PASSED for resource: aws_iam_policy_document.ec2_assume_role_policy
	File: /examples/complete/data.tf:1-10
	Guide: https://docs.bridgecrew.io/docs/bc_aws_iam_43
Check: CKV_AWS_108: "Ensure IAM policies does not allow data exfiltration"
	PASSED for resource: aws_iam_policy_document.ec2_assume_role_policy
	File: /examples/complete/data.tf:1-10
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-data-exfiltration
Check: CKV_AWS_1: "Ensure IAM policies that allow full "*-*" administrative privileges are not created"
	PASSED for resource: aws_iam_policy_document.ec2_assume_role_policy
	File: /examples/complete/data.tf:1-10
	Guide: https://docs.bridgecrew.io/docs/iam_23
Check: CKV_AWS_110: "Ensure IAM policies does not allow privilege escalation"
	PASSED for resource: aws_iam_policy_document.ec2_assume_role_policy
	File: /examples/complete/data.tf:1-10
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-does-not-allow-privilege-escalation
Check: CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
	PASSED for resource: aws_iam_policy_document.ec2_assume_role_policy
	File: /examples/complete/data.tf:1-10
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-permissions-management-resource-exposure-without-constraint
Check: CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
	PASSED for resource: aws_iam_policy_document.ec2_assume_role_policy
	File: /examples/complete/data.tf:1-10
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-write-access-without-constraint
Check: CKV_AWS_107: "Ensure IAM policies does not allow credentials exposure"
	PASSED for resource: aws_iam_policy_document.ec2_assume_role_policy
	File: /examples/complete/data.tf:1-10
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-credentials-exposure
Check: CKV_AWS_49: "Ensure no IAM policies documents allow "*" as a statement's actions"
	PASSED for resource: aws_iam_policy_document.ec2_assume_role_policy
	File: /examples/with_inline_policy/data.tf:1-10
	Guide: https://docs.bridgecrew.io/docs/bc_aws_iam_43
Check: CKV_AWS_108: "Ensure IAM policies does not allow data exfiltration"
	PASSED for resource: aws_iam_policy_document.ec2_assume_role_policy
	File: /examples/with_inline_policy/data.tf:1-10
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-data-exfiltration
Check: CKV_AWS_1: "Ensure IAM policies that allow full "*-*" administrative privileges are not created"
	PASSED for resource: aws_iam_policy_document.ec2_assume_role_policy
	File: /examples/with_inline_policy/data.tf:1-10
	Guide: https://docs.bridgecrew.io/docs/iam_23
Check: CKV_AWS_110: "Ensure IAM policies does not allow privilege escalation"
	PASSED for resource: aws_iam_policy_document.ec2_assume_role_policy
	File: /examples/with_inline_policy/data.tf:1-10
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-does-not-allow-privilege-escalation
Check: CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
	PASSED for resource: aws_iam_policy_document.ec2_assume_role_policy
	File: /examples/with_inline_policy/data.tf:1-10
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-permissions-management-resource-exposure-without-constraint
Check: CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
	PASSED for resource: aws_iam_policy_document.ec2_assume_role_policy
	File: /examples/with_inline_policy/data.tf:1-10
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-write-access-without-constraint
Check: CKV_AWS_107: "Ensure IAM policies does not allow credentials exposure"
	PASSED for resource: aws_iam_policy_document.ec2_assume_role_policy
	File: /examples/with_inline_policy/data.tf:1-10
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-credentials-exposure
Check: CKV_AWS_49: "Ensure no IAM policies documents allow "*" as a statement's actions"
	PASSED for resource: aws_iam_policy_document.inline_policy
	File: /examples/with_inline_policy/data.tf:12-17
	Guide: https://docs.bridgecrew.io/docs/bc_aws_iam_43
Check: CKV_AWS_108: "Ensure IAM policies does not allow data exfiltration"
	PASSED for resource: aws_iam_policy_document.inline_policy
	File: /examples/with_inline_policy/data.tf:12-17
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-data-exfiltration
Check: CKV_AWS_1: "Ensure IAM policies that allow full "*-*" administrative privileges are not created"
	PASSED for resource: aws_iam_policy_document.inline_policy
	File: /examples/with_inline_policy/data.tf:12-17
	Guide: https://docs.bridgecrew.io/docs/iam_23
Check: CKV_AWS_110: "Ensure IAM policies does not allow privilege escalation"
	PASSED for resource: aws_iam_policy_document.inline_policy
	File: /examples/with_inline_policy/data.tf:12-17
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-does-not-allow-privilege-escalation
Check: CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
	PASSED for resource: aws_iam_policy_document.inline_policy
	File: /examples/with_inline_policy/data.tf:12-17
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-permissions-management-resource-exposure-without-constraint
Check: CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
	PASSED for resource: aws_iam_policy_document.inline_policy
	File: /examples/with_inline_policy/data.tf:12-17
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-write-access-without-constraint
Check: CKV_AWS_107: "Ensure IAM policies does not allow credentials exposure"
	PASSED for resource: aws_iam_policy_document.inline_policy
	File: /examples/with_inline_policy/data.tf:12-17
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-credentials-exposure
Check: CKV_AWS_61: "Ensure AWS IAM policy does not allow assume role permission across all services"
	PASSED for resource: module.complete_managed_policy.aws_iam_role.main
	File: /main.tf:1-24
	Calling File: /examples/complete/main.tf:2-17
	Guide: https://docs.bridgecrew.io/docs/bc_aws_iam_45
Check: CKV_AWS_60: "Ensure IAM role allows only specific services or principals to assume it"
	PASSED for resource: module.complete_managed_policy.aws_iam_role.main
	File: /main.tf:1-24
	Calling File: /examples/complete/main.tf:2-17
	Guide: https://docs.bridgecrew.io/docs/bc_aws_iam_44
Check: CKV_AWS_63: "Ensure no IAM policies documents allow "*" as a statement's actions"
	PASSED for resource: module.complete_managed_policy.aws_iam_policy.main
	File: /main.tf:26-32
	Calling File: /examples/complete/main.tf:2-17
	Guide: https://docs.bridgecrew.io/docs/iam_48
Check: CKV_AWS_62: "Ensure IAM policies that allow full "*-*" administrative privileges are not created"
	PASSED for resource: module.complete_managed_policy.aws_iam_policy.main
	File: /main.tf:26-32
	Calling File: /examples/complete/main.tf:2-17
	Guide: https://docs.bridgecrew.io/docs/iam_47
Check: CKV_AWS_61: "Ensure AWS IAM policy does not allow assume role permission across all services"
	PASSED for resource: module.minimum.aws_iam_role.main
	File: /main.tf:1-24
	Calling File: /examples/minimum/main.tf:1-5
	Guide: https://docs.bridgecrew.io/docs/bc_aws_iam_45
Check: CKV_AWS_60: "Ensure IAM role allows only specific services or principals to assume it"
	PASSED for resource: module.minimum.aws_iam_role.main
	File: /main.tf:1-24
	Calling File: /examples/minimum/main.tf:1-5
	Guide: https://docs.bridgecrew.io/docs/bc_aws_iam_44
Check: CKV_AWS_63: "Ensure no IAM policies documents allow "*" as a statement's actions"
	PASSED for resource: module.minimum.aws_iam_policy.main
	File: /main.tf:26-32
	Calling File: /examples/minimum/main.tf:1-5
	Guide: https://docs.bridgecrew.io/docs/iam_48
Check: CKV_AWS_62: "Ensure IAM policies that allow full "*-*" administrative privileges are not created"
	PASSED for resource: module.minimum.aws_iam_policy.main
	File: /main.tf:26-32
	Calling File: /examples/minimum/main.tf:1-5
	Guide: https://docs.bridgecrew.io/docs/iam_47
Check: CKV_AWS_61: "Ensure AWS IAM policy does not allow assume role permission across all services"
	PASSED for resource: module.inline_policy.aws_iam_role.main
	File: /main.tf:1-24
	Calling File: /examples/with_inline_policy/main.tf:1-23
	Guide: https://docs.bridgecrew.io/docs/bc_aws_iam_45
Check: CKV_AWS_60: "Ensure IAM role allows only specific services or principals to assume it"
	PASSED for resource: module.inline_policy.aws_iam_role.main
	File: /main.tf:1-24
	Calling File: /examples/with_inline_policy/main.tf:1-23
	Guide: https://docs.bridgecrew.io/docs/bc_aws_iam_44
Check: CKV_AWS_63: "Ensure no IAM policies documents allow "*" as a statement's actions"
	PASSED for resource: module.inline_policy.aws_iam_policy.main
	File: /main.tf:26-32
	Calling File: /examples/with_inline_policy/main.tf:1-23
	Guide: https://docs.bridgecrew.io/docs/iam_48
Check: CKV_AWS_62: "Ensure IAM policies that allow full "*-*" administrative privileges are not created"
	PASSED for resource: module.inline_policy.aws_iam_policy.main
	File: /main.tf:26-32
	Calling File: /examples/with_inline_policy/main.tf:1-23
	Guide: https://docs.bridgecrew.io/docs/iam_47
```
</details>